### PR TITLE
[CORE] Fix org.jpmml:pmml-model vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
       <dependency>
         <groupId>org.jpmml</groupId>
         <artifactId>pmml-model</artifactId>
-        <version>1.2.15</version>
+        <version>1.4.3</version>
         <scope>provided</scope>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The current code uses org.jpmml:pmml-model:jar:1.2.15 and it will cause a security vulnerabilities. We received some alerts like https://github.com/Qihoo360/XSQL/network/alert/pom.xml/org.jpmml:pmml-model/open
This Alert remind to upgrate the version of pmml-model to 1.4.3 or later.
I referenced Spark 3.0.0 contains pmml-model:jar:1.4.8.