### PR TITLE
[CORE] Fix com.fasterxml.jackson.core:jackson-databind vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,8 +149,8 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
     <snappy.version>1.1.7.3</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>
@@ -658,7 +658,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-        <version>${fasterxml.jackson.databind.version}</version>
+        <version>${fasterxml.jackson.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The current code uses com.fasterxml.jackson.core:jackson-databind:jar:2.6.7.1 and it will cause a security vulnerabilities. We received some alerts like https://github.com/Qihoo360/XSQL/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open
This Alert remind to upgrate the version of `jackson-databind` to 2.9.9.2 or later.
I referenced `Spark 3.0.0` contains `jackson-databind:jar:2.9.9.3` and `jackson-module-scala_2.12:jar:2.9.9`. Because `Spark 3.0.0` uses scala version is 2.12.
`XSQL` uses scala version is 2.11.12, so we should select `jackson-module-scala_2.11:jar:2.9.9` too.