### PR TITLE
[CORE] Upgrade the version of master to 0.7.0-SNAPSHOT.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.11</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-parent_2.11</artifactId>
-  <version>0.6.0</version>
+  <version>0.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Spark Project Parent POM</name>
   <url>http://spark.apache.org/</url>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.11</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.11</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.11</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.11</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/xsql-druid/pom.xml
+++ b/sql/xsql-druid/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-parent_2.11</artifactId>
     <groupId>org.apache.spark</groupId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/sql/xsql-hbase/pom.xml
+++ b/sql/xsql-hbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-parent_2.11</artifactId>
     <groupId>org.apache.spark</groupId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/sql/xsql-monitor/pom.xml
+++ b/sql/xsql-monitor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-parent_2.11</artifactId>
     <groupId>org.apache.spark</groupId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/sql/xsql-shell/pom.xml
+++ b/sql/xsql-shell/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.11</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/xsql/pom.xml
+++ b/sql/xsql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.11</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
**What changes were proposed in this pull request?**
`XSQL` have been released 0.6.0, so we should upgrade the version of master to `0.7.0-SNAPSHOT`.
I think this is a good deal references `Apache Spark`.
The branch 0.6 will continue to fix bug and release 0.6.1, 0.6.2 and so on.