### PR TITLE
fix the bug that can't find default database when default database's name is not default

### DIFF
--- a/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
+++ b/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
@@ -161,7 +161,7 @@ object SparkXSQLShell extends Logging {
     def run(commands: String, silent: Boolean = false) = {
       var startTime = System.currentTimeMillis()
       for (command <- commands.split(";")) {
-        var sql = command.trim()
+        var sql = command.trim().replaceAll("[\\t\\n\\r]", " ")
         if (sql != "") {
           if (sql.equals("exit") || sql.equals("quit")) {
             exit()
@@ -230,8 +230,6 @@ object SparkXSQLShell extends Logging {
             if (!restarted && sql.toLowerCase.contains("select ") &&
                 spark.sparkContext.isLocal && originMaster != "local") {
               val parsed = spark.sessionState.sqlParser.parsePlan(sql)
-              val analyzed = spark.sessionState.analyzer.executeAndCheck(parsed)
-              val optimized = spark.sessionState.optimizer.execute(analyzed)
               if (resolve.isRunOnYarn(parsed)) {
                 restart(resolve.selectYarnCluster(parsed))
                 setDescription(sql)

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -80,6 +80,8 @@ private[xsql] class XSQLSessionCatalog(
   val xsqlExternalCatalog =
     externalCatalogWithListener.unwrapped.asInstanceOf[XSQLExternalCatalog]
 
+  setCurrentDatabase(getCurrentCatalogDatabase.get.name)
+
   /**
    * Get default cluster.
    */


### PR DESCRIPTION
**What changes were proposed in this pull request?**
the pr add this method of setCurrentDatabase to change currentDb in SessionCatalog.
it solve the bug can't find default database when we set the value of spark.default.database is not default,
eg: `spark.default.database = test`