### PR TITLE
[CORE] Replace prefix of artifactId from spark to xsql.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -25,7 +25,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-assembly_2.11</artifactId>
+  <artifactId>xsql-assembly_2.11</artifactId>
   <name>Spark Project Assembly</name>
   <url>http://spark.apache.org/</url>
   <packaging>pom</packaging>
@@ -66,8 +66,20 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>xsql-sql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.spark</groupId>
@@ -168,12 +180,12 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-xsql_${scala.binary.version}</artifactId>
+          <artifactId>xsql_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-xsql-shell_${scala.binary.version}</artifactId>
+          <artifactId>xsql-shell_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>
@@ -183,7 +195,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-xsql-monitor_2.11</artifactId>
+          <artifactId>xsql-monitor_2.11</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>
@@ -193,8 +205,14 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive_${scala.binary.version}</artifactId>
+          <artifactId>xsql-hive_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-hive_${scala.binary.version}</artifactId>
+          <version>${spark.version}</version>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -203,8 +221,14 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
+          <artifactId>xsql-hive-thriftserver_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
+          <version>${spark.version}</version>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
     </profile>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -208,12 +208,6 @@
           <artifactId>xsql-hive_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
         </dependency>
-        <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive_${scala.binary.version}</artifactId>
-          <version>${spark.version}</version>
-          <scope>provided</scope>
-        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -223,12 +217,6 @@
           <groupId>org.apache.spark</groupId>
           <artifactId>xsql-hive-thriftserver_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
-          <version>${spark.version}</version>
-          <scope>provided</scope>
         </dependency>
       </dependencies>
     </profile>

--- a/assembly/src/main/assembly/xsql-plugin-assembly.xml
+++ b/assembly/src/main/assembly/xsql-plugin-assembly.xml
@@ -41,11 +41,11 @@
   <dependencySets>
     <dependencySet>
       <includes>
-        <include>org.apache.spark:spark-catalyst_2.11</include>
-        <include>org.apache.spark:spark-sql_2.11</include>
-        <include>org.apache.spark:spark-hive_2.11</include>
-        <include>org.apache.spark:spark-hive-thriftserver_2.11</include>
-        <include>org.apache.spark:spark-xsql*:jar</include>
+        <include>org.apache.spark:xsql-catalyst_2.11</include>
+        <include>org.apache.spark:xsql-sql_2.11</include>
+        <include>org.apache.spark:xsql-hive_2.11</include>
+        <include>org.apache.spark:xsql-hive-thriftserver_2.11</include>
+        <include>org.apache.spark:xsql*:jar</include>
       </includes>
       <outputDirectory>xsql-jars</outputDirectory>
     </dependencySet>

--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -9,7 +9,7 @@ SPARK_VERSION=$(mvn help:evaluate -Dexpression=spark.version $@ 2>/dev/null\
     | grep -v "INFO"\
     | grep -v "WARNING"\
     | tail -n 1)
-TGZ_NAME=spark-assembly_2.11-$VERSION-dist.tgz
+TGZ_NAME=xsql-assembly_2.11-$VERSION-dist.tgz
 FINAL_NAME=xsql-$VERSION-plugin-spark-$SPARK_VERSION.tgz
 cd assembly/target
 mv $TGZ_NAME ../../$FINAL_NAME

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-catalyst_2.11</artifactId>
+  <artifactId>xsql-catalyst_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Catalyst</name>
   <url>http://spark.apache.org/</url>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-sql_2.11</artifactId>
+  <artifactId>xsql-sql_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project SQL</name>
   <url>http://spark.apache.org/</url>
@@ -57,12 +57,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <artifactId>xsql-catalyst_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <artifactId>xsql-catalyst_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-hive-thriftserver_2.11</artifactId>
+  <artifactId>xsql-hive-thriftserver_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Hive Thrift Server</name>
   <url>http://spark.apache.org/</url>
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <artifactId>xsql-hive_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>xsql-sql_${scala.binary.version}</artifactId>
       <type>test-jar</type>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-hive_2.11</artifactId>
+  <artifactId>xsql-hive_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Hive</name>
   <url>http://spark.apache.org/</url>
@@ -52,19 +52,19 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>xsql-sql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>xsql-sql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <artifactId>xsql-catalyst_${scala.binary.version}</artifactId>
       <type>test-jar</type>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/sql/xsql-druid/pom.xml
+++ b/sql/xsql-druid/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Spark Project XSQL Druid Connector</name>
-  <artifactId>spark-xsql-druid_2.11</artifactId>
+  <artifactId>xsql-druid_2.11</artifactId>
   <properties>
     <build.testJarPhase>none</build.testJarPhase>
   </properties>
@@ -22,13 +22,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-xsql_${scala.binary.version}</artifactId>
+      <artifactId>xsql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>xsql-sql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/sql/xsql-hbase/pom.xml
+++ b/sql/xsql-hbase/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Spark Project XSQL HBase Connector</name>
-  <artifactId>spark-xsql-hbase_2.11</artifactId>
+  <artifactId>xsql-hbase_2.11</artifactId>
   <properties>
     <build.testJarPhase>none</build.testJarPhase>
     <hbase.version>2.0.0</hbase.version>
@@ -33,13 +33,13 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-xsql_${scala.binary.version}</artifactId>
+      <artifactId>xsql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>xsql-sql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/sql/xsql-monitor/pom.xml
+++ b/sql/xsql-monitor/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Spark Project XSQL Monitor</name>
-  <artifactId>spark-xsql-monitor_2.11</artifactId>
+  <artifactId>xsql-monitor_2.11</artifactId>
 
   <properties>
     <common.email.ver>1.5</common.email.ver>

--- a/sql/xsql-shell/pom.xml
+++ b/sql/xsql-shell/pom.xml
@@ -10,7 +10,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-xsql-shell_2.11</artifactId>
+  <artifactId>xsql-shell_2.11</artifactId>
   <name>Spark Project XSQL SHELL</name>
 
   <dependencies>
@@ -34,7 +34,7 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_2.11</artifactId>
+      <artifactId>xsql-hive_2.11</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -47,7 +47,7 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-xsql_2.11</artifactId>
+      <artifactId>xsql_2.11</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/sql/xsql/pom.xml
+++ b/sql/xsql/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-xsql_2.11</artifactId>
+  <artifactId>xsql_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project XSQL</name>
   <url>http://spark.apache.org/</url>
@@ -62,7 +62,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>xsql-sql_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <artifactId>xsql-catalyst_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <artifactId>xsql-hive_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
If we build XSQL, then some jars created as follows:
```
spark-catalyst_2.11.jar
spark-sql_2.11.jar
spark-xsql_2.11.jar
spark-xsql-druid_2.11.jar
spark-xsql-hbase_2.11.jar
spark-xsql-monitor_2.11.jar
spark-xsql-shell_2.11.jar
```
But there exists two issues. First, the name of some jars ( e.g. spark-catalyst_2.11.jar ) is the same as the jars released by `Apache Spark`. This issue will lead to some conflict about dependency. Second, some jars ( e.g. spark-xsql-shell_2.11.jar ) is exactly XSQL  component.
