### PR TITLE
[CORE] Fix the bug that can't find default database when default database's name is not default

### DIFF
--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -81,8 +81,9 @@ private[xsql] class XSQLSessionCatalog(
     externalCatalogWithListener.unwrapped.asInstanceOf[XSQLExternalCatalog]
 
   /**
-    * Reset currentDb in SessionCatalog.
-    * Keep the currentDb in SessionCatalog and currentDataBase in XSQLExternalCatalog the same
+    * Reset `currentDb` in [[SessionCatalog]].
+    * Keep the `currentDb` in [[SessionCatalog]] and
+    * `currentDataBase` in [[XSQLExternalCatalog]] the same.
     */
   val catalogDB = getCurrentCatalogDatabase.get
   setCurrentDatabase(catalogDB.dataSourceName, catalogDB.name)

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -82,7 +82,7 @@ private[xsql] class XSQLSessionCatalog(
 
   /**
     * Reset currentDb in SessionCatalog.
-    * Keep the same currentDb in SessionCatalog and XSQLExternalCatalog.
+    * Keep the currentDb in SessionCatalog and currentDataBase in XSQLExternalCatalog the same
     */
   val catalogDB = getCurrentCatalogDatabase.get
   setCurrentDatabase(catalogDB.dataSourceName, catalogDB.name)

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -79,8 +79,10 @@ private[xsql] class XSQLSessionCatalog(
   assert(externalCatalogWithListener.unwrapped.isInstanceOf[XSQLExternalCatalog])
   val xsqlExternalCatalog =
     externalCatalogWithListener.unwrapped.asInstanceOf[XSQLExternalCatalog]
+
   /**
-    * Synchronize currentDb of SessionCatalog with XSQLExternalCatalog
+    * Reset currentDb in SessionCatalog.
+    * Keep the same currentDb in SessionCatalog and XSQLExternalCatalog.
     */
   val catalogDB = getCurrentCatalogDatabase.get
   setCurrentDatabase(catalogDB.dataSourceName, catalogDB.name)

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -81,9 +81,9 @@ private[xsql] class XSQLSessionCatalog(
     externalCatalogWithListener.unwrapped.asInstanceOf[XSQLExternalCatalog]
 
   /**
-    * Set `currentDb` in [[SessionCatalog]].
-    * Keep the `currentDb` in [[SessionCatalog]] and
-    * `currentDataBase` in [[XSQLExternalCatalog]] the same.
+    * Keep the `currentDb` in [[SessionCatalog]] and `currentDataBase` in
+    * [[XSQLExternalCatalog]] the same when initializing [[SessionCatalog]].
+    * See https://github.com/Qihoo360/XSQL/pull/21 for additional details
     */
   val catalogDB = getCurrentCatalogDatabase.get
   setCurrentDatabase(catalogDB.dataSourceName, catalogDB.name)

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -81,7 +81,7 @@ private[xsql] class XSQLSessionCatalog(
     externalCatalogWithListener.unwrapped.asInstanceOf[XSQLExternalCatalog]
 
   /**
-    * Reset `currentDb` in [[SessionCatalog]].
+    * Set `currentDb` in [[SessionCatalog]].
     * Keep the `currentDb` in [[SessionCatalog]] and
     * `currentDataBase` in [[XSQLExternalCatalog]] the same.
     */

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -79,8 +79,11 @@ private[xsql] class XSQLSessionCatalog(
   assert(externalCatalogWithListener.unwrapped.isInstanceOf[XSQLExternalCatalog])
   val xsqlExternalCatalog =
     externalCatalogWithListener.unwrapped.asInstanceOf[XSQLExternalCatalog]
-
-  setCurrentDatabase(getCurrentCatalogDatabase.get.name)
+  /**
+    * Synchronize currentDb of SessionCatalog with XSQLExternalCatalog
+    */
+  val catalogDB = getCurrentCatalogDatabase.get
+  setCurrentDatabase(catalogDB.dataSourceName, catalogDB.name)
 
   /**
    * Get default cluster.

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -80,6 +80,8 @@ private[xsql] class XSQLSessionCatalog(
   val xsqlExternalCatalog =
     externalCatalogWithListener.unwrapped.asInstanceOf[XSQLExternalCatalog]
 
+  setCurrentDatabase(getCurrentCatalogDatabase.get.name)
+
   /**
    * Get default cluster.
    */


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The PR add the code of `setCurrentDatabase` to change `currentDb` in `SessionCatalog` and keep  the  `currentDb` in `SessionCatalog` and `currentDataBase` in `XSQLExternalCatalog` the same.
It solve the bug that can't find database when we set the value of `spark.xsql.default.database` is not “default”。
eg:
When we configured the following parameters：
```
spark.xsql.default.datasource     mysql
spark.xsql.default.database   test
```
The following error will appear：
error：
```
org.apache.spark.sql.AnalysisException: org.apache.spark.sql.AnalysisException: org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException: Database 'mysql.default' not found;;;
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.liftedTree2$1(XSQLExternalCatalog.scala:657)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.withWorkingDSDB(XSQLExternalCatalog.scala:647)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.getTable(XSQLExternalCatalog.scala:809)
        at org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener.getTable(ExternalCatalogWithListener.scala:138)
        at org.apache.spark.sql.catalyst.catalog.SessionCatalog.lookupRelation(SessionCatalog.scala:706)
        at org.apache.spark.sql.xsql.XSQLSessionCatalog.org$apache$spark$sql$xsql$XSQLSessionCatalog$$super$lookupRelation(XSQLSessionCatalog.scala:437)
        at org.apache.spark.sql.xsql.XSQLSessionCatalog$$anonfun$lookupRelation$1.apply(XSQLSessionCatalog.scala:437)
        at org.apache.spark.sql.xsql.XSQLSessionCatalog$$anonfun$lookupRelation$1.apply(XSQLSessionCatalog.scala:437)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.setWorkingDataSource(XSQLExternalCatalog.scala:610)
        at org.apache.spark.sql.xsql.XSQLSessionCatalog.setWorkingDataSource(XSQLSessionCatalog.scala:143)
        at org.apache.spark.sql.xsql.XSQLSessionCatalog.lookupRelation(XSQLSessionCatalog.scala:436)
        at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$.org$apache$spark$sql$xsql$XSQLSessionStateBuilder$XSQLResolveRelations$$lookupTableFromCatalog(XSQLSessionStateBuilder.scala:283)
        at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$.resolveRelation(XSQLSessionStateBuilder.scala:236)
        at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$$anonfun$apply$1.applyOrElse(XSQLSessionStateBuilder.scala:266)
        at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$$anonfun$apply$1.applyOrElse(XSQLSessionStateBuilder.scala:259)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1$$anonfun$apply$1.apply(AnalysisHelper.scala:90)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1$$anonfun$apply$1.apply(AnalysisHelper.scala:90)
        at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:70)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1.apply(AnalysisHelper.scala:89)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1.apply(AnalysisHelper.scala:86)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.allowInvokingTransformsInAnalyzer(AnalysisHelper.scala:194)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$class.resolveOperatorsUp(AnalysisHelper.scala:86)
        at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveOperatorsUp(LogicalPlan.scala:29)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1$$anonfun$1.apply(AnalysisHelper.scala:87)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1$$anonfun$1.apply(AnalysisHelper.scala:87)
        at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$4.apply(TreeNode.scala:326)
        at org.apache.spark.sql.catalyst.trees.TreeNode.mapProductIterator(TreeNode.scala:187)
        at org.apache.spark.sql.catalyst.trees.TreeNode.mapChildren(TreeNode.scala:324)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1.apply(AnalysisHelper.scala:87)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1.apply(AnalysisHelper.scala:86)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.allowInvokingTransformsInAnalyzer(AnalysisHelper.scala:194)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$class.resolveOperatorsUp(AnalysisHelper.scala:86)
        at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveOperatorsUp(LogicalPlan.scala:29)
        at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$.apply(XSQLSessionStateBuilder.scala:259)
        at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$.apply(XSQLSessionStateBuilder.scala:204)
        at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$execute$1$$anonfun$apply$1.apply(RuleExecutor.scala:87)
        at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$execute$1$$anonfun$apply$1.apply(RuleExecutor.scala:84)
        at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:124)
        at scala.collection.immutable.List.foldLeft(List.scala:84)
        at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$execute$1.apply(RuleExecutor.scala:84)
        at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$execute$1.apply(RuleExecutor.scala:76)
        at scala.collection.immutable.List.foreach(List.scala:392)
        at org.apache.spark.sql.catalyst.rules.RuleExecutor.execute(RuleExecutor.scala:76)
        at org.apache.spark.sql.catalyst.analysis.Analyzer.org$apache$spark$sql$catalyst$analysis$Analyzer$$executeSameContext(Analyzer.scala:127)
        at org.apache.spark.sql.catalyst.analysis.Analyzer.execute(Analyzer.scala:121)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$$anonfun$executeAndCheck$1.apply(Analyzer.scala:106)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$$anonfun$executeAndCheck$1.apply(Analyzer.scala:105)
        at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.markInAnalyzer(AnalysisHelper.scala:201)
        at org.apache.spark.sql.catalyst.analysis.Analyzer.executeAndCheck(Analyzer.scala:105)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$$anonfun$org$apache$spark$sql$xsql$shell$SparkXSQLShell$$run$1$1.apply(SparkXSQLShell.scala:233)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$$anonfun$org$apache$spark$sql$xsql$shell$SparkXSQLShell$$run$1$1.apply(SparkXSQLShell.scala:163)
        at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
        at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$.org$apache$spark$sql$xsql$shell$SparkXSQLShell$$run$1(SparkXSQLShell.scala:163)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$.process$1(SparkXSQLShell.scala:295)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$.org$apache$spark$sql$xsql$shell$SparkXSQLShell$$loop$1(SparkXSQLShell.scala:335)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$$anonfun$main$2.apply(SparkXSQLShell.scala:93)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$$anonfun$main$2.apply(SparkXSQLShell.scala:75)
        at scala.Option.map(Option.scala:146)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell$.main(SparkXSQLShell.scala:75)
        at org.apache.spark.sql.xsql.shell.SparkXSQLShell.main(SparkXSQLShell.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
        at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:845)
        at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:161)
        at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:184)
        at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:86)
        at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:920)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:929)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: org.apache.spark.sql.AnalysisException: org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException: Database 'mysql.default' not found;;
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.liftedTree1$1(XSQLExternalCatalog.scala:634)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.withWorkingDS(XSQLExternalCatalog.scala:624)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.getDatabase(XSQLExternalCatalog.scala:554)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.liftedTree2$1(XSQLExternalCatalog.scala:648)
        ... 72 more
Caused by: org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException: Database 'mysql.default' not found;
        at org.apache.spark.sql.xsql.XSQLExternalCatalog$$anonfun$getDatabase$1$$anonfun$apply$4.apply(XSQLExternalCatalog.scala:557)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog$$anonfun$getDatabase$1$$anonfun$apply$4.apply(XSQLExternalCatalog.scala:557)
        at scala.Option.getOrElse(Option.scala:121)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog$$anonfun$getDatabase$1.apply(XSQLExternalCatalog.scala:557)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog$$anonfun$getDatabase$1.apply(XSQLExternalCatalog.scala:554)
        at org.apache.spark.sql.xsql.XSQLExternalCatalog.liftedTree1$1(XSQLExternalCatalog.scala:625)
        ... 75 more
```