### PR TITLE
[SHELL] Solve sql select query that select is followed by \n can't run  when we use -e sql

### DIFF
--- a/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
+++ b/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
@@ -161,7 +161,7 @@ object SparkXSQLShell extends Logging {
     def run(commands: String, silent: Boolean = false) = {
       var startTime = System.currentTimeMillis()
       for (command <- commands.split(";")) {
-        var sql = command.trim()
+        var sql = command.trim().replaceAll("[\\t\\n\\r]", " ")
         if (sql != "") {
           if (sql.equals("exit") || sql.equals("quit")) {
             exit()
@@ -230,8 +230,6 @@ object SparkXSQLShell extends Logging {
             if (!restarted && sql.toLowerCase.contains("select ") &&
                 spark.sparkContext.isLocal && originMaster != "local") {
               val parsed = spark.sessionState.sqlParser.parsePlan(sql)
-              val analyzed = spark.sessionState.analyzer.executeAndCheck(parsed)
-              val optimized = spark.sessionState.optimizer.execute(analyzed)
               if (resolve.isRunOnYarn(parsed)) {
                 restart(resolve.selectYarnCluster(parsed))
                 setDescription(sql)

--- a/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
+++ b/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
@@ -231,6 +231,8 @@ object SparkXSQLShell extends Logging {
                 sql.toLowerCase.contains("select\\n")) &&
                 spark.sparkContext.isLocal && originMaster != "local") {
               val parsed = spark.sessionState.sqlParser.parsePlan(sql)
+              val analyzed = spark.sessionState.analyzer.executeAndCheck(parsed)
+              val optimized = spark.sessionState.optimizer.execute(analyzed)
               if (resolve.isRunOnYarn(parsed)) {
                 restart(resolve.selectYarnCluster(parsed))
                 setDescription(sql)

--- a/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
+++ b/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
@@ -161,7 +161,7 @@ object SparkXSQLShell extends Logging {
     def run(commands: String, silent: Boolean = false) = {
       var startTime = System.currentTimeMillis()
       for (command <- commands.split(";")) {
-        var sql = command.trim().replaceAll("[\\t\\n\\r]", " ")
+        var sql = command.trim()
         if (sql != "") {
           if (sql.equals("exit") || sql.equals("quit")) {
             exit()
@@ -227,7 +227,8 @@ object SparkXSQLShell extends Logging {
           }
           if (!silent && !sql.toLowerCase.startsWith("add") && !sql.toLowerCase.startsWith("set")) {
             //modify for spark2.3 , to first start local , then restart scheduler
-            if (!restarted && sql.toLowerCase.contains("select ") &&
+            if (!restarted && (sql.toLowerCase.contains("select ") ||
+                sql.toLowerCase.contains("select\\n")) &&
                 spark.sparkContext.isLocal && originMaster != "local") {
               val parsed = spark.sessionState.sqlParser.parsePlan(sql)
               if (resolve.isRunOnYarn(parsed)) {


### PR DESCRIPTION
**What changes were proposed in this pull request?**
When we use -e to execute a select sql that select is followed \n,the application will be stuck,this PR solve this problem.
eg：
```
./bin/spark-xsql -e "
select 
    cola,
    colb
from tableA
"
```