### PR TITLE
[SHELL][BUILD] Fix scala compiler vulnerabilities in xsql-shell

### DIFF
--- a/sql/xsql-shell/pom.xml
+++ b/sql/xsql-shell/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>2.11.8</version>
+      <version>${scala.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The current code uses org.scala-lang:scala-compiler:jar:2.11.8 and it will cause a security vulnerabilities. 
We received some alerts like [https://github.com/Qihoo360/XSQL/network/alert/sql/xsql-shell/pom.xml/org.scala-lang:scala-compiler/open](https://github.com/Qihoo360/XSQL/network/alert/sql/xsql-shell/pom.xml/org.scala-lang:scala-compiler/open)
This Alert remind to upgrate the version of org.scala-lang:scala-compiler >= 2.11.0, < 2.11.12 defined in pom.xml.
pom.xml update suggested: org.scala-lang:scala-compiler ~> 2.11.12

