### PR TITLE
[CORE] Fix zookeeper vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <flume.version>1.6.0</flume.version>
-    <zookeeper.version>3.4.6</zookeeper.version>
+    <zookeeper.version>3.4.14</zookeeper.version>
     <curator.version>2.6.0</curator.version>
     <hive.group>org.xitong-spark-project.hive</hive.group>
     <!-- Version used in Maven Hive dependency -->


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The current code uses org.apache.zookeeper:zookeeper:jar:3.4.6 and it will cause a security vulnerabilities. We received some alerts like https://github.com/Qihoo360/XSQL/network/alert/pom.xml/org.apache.zookeeper:zookeeper/open
This Alert remind to upgrate the version of zookeeper to 3.4.14 or later.