### PR TITLE
[CORE] Fix the bug that spark-shell of XSQL cann't start

### DIFF
--- a/sql/xsql-shell/pom.xml
+++ b/sql/xsql-shell/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.12.1</version>
     </dependency>
 
     <dependency>
@@ -61,27 +60,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <shadedArtifactAttached>false</shadedArtifactAttached>
-          <artifactSet>
-            <includes>
-              <include>jline:jline</include>
-              <include>com.github.scopt:scopt_2.11</include>
-            </includes>
-          </artifactSet>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.2</version>
         <configuration>
@@ -111,4 +89,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>xsql-plugin</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <artifactSet>
+                <includes>
+                  <include>com.github.scopt:scopt_2.11</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
As jline has be pre-configured in spark-parent by dependencyManagement, we should not set a different version of jline in spark-shell again. What's more, jline has been packaged by spark-assembly, there is no need to shade it into spark-shell jar in XSQL `plugin` version.