### PR TITLE
[BUILD] build-plugin.sh should use build/mvn to find mvn or install mvn

### DIFF
--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=512m}"
-mvn package -Pxsql -Phive -Phive-thriftserver -Pyarn -DskipTests -Pxsql-plugin -am -pl assembly
-VERSION=$(mvn help:evaluate -Dexpression=project.version $@ 2>/dev/null\
+SPARK_HOME="$(cd `dirname "$0"`; pwd)"
+MVN="$SPARK_HOME/build/mvn"
+"$MVN" package -Pxsql -Phive -Phive-thriftserver -Pyarn -DskipTests -Pxsql-plugin -am -pl assembly
+VERSION=$("$MVN" help:evaluate -Dexpression=project.version $@ 2>/dev/null\
     | grep -v "INFO"\
     | grep -v "WARNING"\
     | tail -n 1)
-SPARK_VERSION=$(mvn help:evaluate -Dexpression=spark.version $@ 2>/dev/null\
+SPARK_VERSION=$("$MVN" help:evaluate -Dexpression=spark.version $@ 2>/dev/null\
     | grep -v "INFO"\
     | grep -v "WARNING"\
     | tail -n 1)


### PR DESCRIPTION
**What changes were proposed in this pull request?**
We should make build-plugin.sh more like dev/make-distribution.sh, which can find or install maven gently.