### PR TITLE
[CORE] Fix puppycrawl vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2579,7 +2579,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.23</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2579,7 +2579,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.2</version>
+            <version>8.23</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The current code uses com.puppycrawl.tools:checkstyle:8.2 and it will cause a security vulnerabilities.
 We received some alerts like https://github.com/Qihoo360/XSQL/network/alert/pom.xml/com.puppycrawl.tools:checkstyle/open
This Alert remind to Upgrade com.puppycrawl.tools:checkstyle to version 8.18 or later.
The jetty version used in spark3.0 is 8.23