### PR TITLE
[CORE] Fix libthrift vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <joda.version>2.9.3</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>1.3.9</jsr305.version>
-    <libthrift.version>0.9.3</libthrift.version>
+    <libthrift.version>0.12.0</libthrift.version>
     <antlr4.version>4.7</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>2.52.0</selenium.version>
@@ -1976,7 +1976,7 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libfb303</artifactId>
-        <version>${libthrift.version}</version>
+        <version>0.9.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The current code uses `org.apache.thrift:libthrift:jar:0.9.3` and it will cause a security vulnerabilities. We received some alerts like https://github.com/Qihoo360/XSQL/network/alert/pom.xml/org.apache.thrift:libthrift/open
This Alert remind to upgrate the version of libthrift to 0.12.0 or later.
I referenced Spark 3.0.0 contains `libthrift:jar:0.12.0` too.
The pom.xml contains the variable `libthrift.version` which is used by `libthrift` and `libfb303`. If upgrade `libthrift.version` to 0.12.0 will lead to an issue `libfb303:jar:0.12.0` can't be find.
So this PR retain `libfb303` with version 0.9.3 and upgrade `libthrift` to 0.12.0.