### PR TITLE
[BUILD] Upgrade jackson-databind to 2.9.10 and fix vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,8 +149,8 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.9.10</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.9.10</fasterxml.jackson.databind.version>
     <snappy.version>1.1.7.3</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The current code uses com.fasterxml.jackson.core:jackson-databind:jar:2.9.9.3 and it will cause a security vulnerabilities. We received some alerts like 
https://github.com/Qihoo360/XSQL/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open
This Alert remind to upgrate the version of `jackson-databind` to 2.9.10 or later.