### PR TITLE
[CORE] .hiverc is loaded twice making create function throw exception

### DIFF
--- a/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
+++ b/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
@@ -108,7 +108,8 @@ object SparkXSQLShell extends Logging {
       sqlContext = spark.sqlContext
       conf = spark.sparkContext.getConf
       sc = spark.sparkContext
-      processInitFile(conf)
+      // we shouldn't load .hiverc twice
+      // processInitFile(conf)
     }
 
     def initialize(sqlContent: String, conf: SparkConf) = {

--- a/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
+++ b/sql/xsql-shell/src/main/scala/org/apache/spark/sql/xsql/shell/SparkXSQLShell.scala
@@ -108,7 +108,8 @@ object SparkXSQLShell extends Logging {
       sqlContext = spark.sqlContext
       conf = spark.sparkContext.getConf
       sc = spark.sparkContext
-      // we shouldn't load .hiverc twice
+      // Don't call processInitFile again to avoid load .hiverc twice.
+      // For more details, please see https://github.com/Qihoo360/XSQL/pull/45
       // processInitFile(conf)
     }
 


### PR DESCRIPTION
**What changes were proposed in this pull request**
If user's `.hiverc` contains sql like 'create temporary function funA as xx.xx', bin/spark-xsql will register it in functionRegistry of local `SparkSession`'s `XSQLSessionCatalog` in the beginning. When some sql causes `SparkSession` restart to run on yarn,  the old `XSQLSessionCatalog` is passed to new started `SparkSession`. It's meaning that funA has existed in functionRegistry. So we should not run `.hiverc` again after SparkSession is restarted.