### PR TITLE
[MONGO] Add mongo license to MongoUtils.

### DIFF
--- a/sql/xsql/src/main/scala/com/mongodb/spark/sql/xsql/MongoUtils.scala
+++ b/sql/xsql/src/main/scala/com/mongodb/spark/sql/xsql/MongoUtils.scala
@@ -14,6 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Based on MapFunctions.scala from MongoDB Spark Connector
+ *
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.spark.sql.xsql
 
 import com.mongodb.spark.sql.BsonValueToJson


### PR DESCRIPTION
### What changes were proposed in this pull request?
`MongoUtils` exists some function based on `com.mongodb.spark.sql.MapFunctions` which is belonged to the project MongoDB Spark Connector.
This PR will add the license of MongoDB.

### How was this patch tested?
No UT.

