### PR TITLE
[BUILD] Upgrade netty-all to 4.1.42 and fix vulnerability.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -601,7 +601,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.17.Final</version>
+        <version>4.1.42.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current code uses io.netty:netty-all:jar:4.1.17 and it will cause a security vulnerabilities. We could get some security info from https://www.tenable.com/cve/CVE-2019-16869.

This reference remind to upgrate the version of netty-all to 4.1.42 or later.

### How was this patch tested?
No UT.

