### PR TITLE
[JDBC] Fix mysql datasource can't partition

### DIFF
--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/manager/MysqlManager.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/manager/MysqlManager.scala
@@ -111,9 +111,8 @@ private[xsql] class MysqlManager(conf: SparkConf) extends DataSourceManager with
       dsName: String,
       dbName: String,
       tbName: String): Unit = {
-    val tablePartitionsMap = partitionsMap.get(dbName)
-    if (tablePartitionsMap != None) {
-      tablePartitionsMap.get.get(tbName).foreach { m =>
+    partitionsMap.get(dbName).foreach { tablePartitionsMap =>
+      tablePartitionsMap.get(tbName).foreach {m =>
         specialProperties += ((s"${dsName}.${dbName}.${tbName}", m))
       }
     }

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/manager/MysqlManager.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/manager/MysqlManager.scala
@@ -112,14 +112,10 @@ private[xsql] class MysqlManager(conf: SparkConf) extends DataSourceManager with
       dbName: String,
       tbName: String): Unit = {
     val tablePartitionsMap = partitionsMap.get(dbName)
-    var partitionsParameters = new HashMap[String, String]
     if (tablePartitionsMap != None) {
-      if (tablePartitionsMap.get.get(tbName) != None) {
-        partitionsParameters = tablePartitionsMap.get.get(tbName).get
+      tablePartitionsMap.get.get(tbName).foreach { m =>
+        specialProperties += ((s"${dsName}.${dbName}.${tbName}", m))
       }
-    }
-    if (partitionsParameters.nonEmpty) {
-      specialProperties += ((s"${dsName}.${dbName}.${tbName}", partitionsParameters))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR solves the problem that MySQL data source can't partition. The current code don't load partition information of MySQL into memory when `cache.level` is 1 . The PR fixes the bug.

### How was this patch tested?
No UT.