### PR TITLE
[BUILD] Bump fasterxml.jackson from 2.9.10 to 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,8 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.9.10</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.9.10</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.10.0</fasterxml.jackson.databind.version>
     <snappy.version>1.1.7.3</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current code uses com.fasterxml.jackson.core:jackson-databind:jar:2.9.10 and it will cause a security vulnerabilities. 
We referenced https://github.com/advisories/GHSA-mx7p-6679-8g3q
This Alert remind to upgrate the version of jackson-databind to 2.9.10.1 or later.
I referenced Spark 3.0.0 contains jackson-databind:jar:2.10.0.

### How was this patch tested?
No UT now.

