### PR TITLE
[CORE]Fix the bug that don't pushdown mysql datasource when there are some spark-provided functions in subquery

### DIFF
--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/execution/datasources/mysql/MysqlSpecialStrategy.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/execution/datasources/mysql/MysqlSpecialStrategy.scala
@@ -487,18 +487,16 @@ class TransmitOriginalQuery(session: SparkSession) extends Rule[LogicalPlan] {
             } else {
               a.child
             }
-            if (!pushdownFunctions.contains(func.prettyName)) {
-              true
-            } else {
+            if (pushdownFunctions.contains(func.prettyName)) {
               false
+            } else {
+              true
             }
           }
         case _ => false
       }
     }
-    plan.find {
-      functionNotPushdown
-    }.isEmpty
+    plan.find(functionNotPushdown).isEmpty
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR solved the first question about Issues[61]https://github.com/Qihoo360/XSQL/issues/61, don't `pushdown `MySQL `datasource `when there are some functions  provided by spark in subquery.


### How was this patch tested?
No UT now.

