### PR TITLE
[Core] Fix deadLock between XSQLSessionCatalog and workingDataSource

### DIFF
--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLExternalCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLExternalCatalog.scala
@@ -594,9 +594,7 @@ private[xsql] class XSQLExternalCatalog(conf: SparkConf, hadoopConf: Configurati
 
   override def setCurrentDatabase(dbName: String): Unit = {
     withWorkingDSDB(dbName) { (_, db, _, _) =>
-      synchronized{
-        currentDataBase = Option(db)
-      }
+      currentDataBase = Option(db)
     }
   }
 

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLExternalCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLExternalCatalog.scala
@@ -594,7 +594,9 @@ private[xsql] class XSQLExternalCatalog(conf: SparkConf, hadoopConf: Configurati
 
   override def setCurrentDatabase(dbName: String): Unit = {
     withWorkingDSDB(dbName) { (_, db, _, _) =>
-      currentDataBase = Option(db)
+      synchronized{
+        currentDataBase = Option(db)
+      }
     }
   }
 

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/XSQLSessionCatalog.scala
@@ -211,11 +211,9 @@ private[xsql] class XSQLSessionCatalog(
   }
 
   def setCurrentDatabase(dsName: String, dbName: String): Unit = {
-    synchronized {
-      setWorkingDataSource(Option(dsName)) {
-        super.setCurrentDatabase(dbName)
-        externalCatalog.setCurrentDatabase(dbName)
-      }
+    setWorkingDataSource(Option(dsName)) {
+      super.setCurrentDatabase(dbName)
+      externalCatalog.setCurrentDatabase(dbName)
     }
   }
 
@@ -407,18 +405,17 @@ private[xsql] class XSQLSessionCatalog(
   // | Methods that interact with temporary and metastore tables |
   // -------------------------------------------------------------
 
-  override def renameTable(oldName: TableIdentifier, newName: TableIdentifier): Unit =
-    synchronized {
-      val oldDs = getDataSourceName(oldName)
-      val newDs = getDataSourceName(newName)
-      if (oldDs != newDs) {
-        throw new AnalysisException(
-          s"RENAME TABLE source and destination datasources do not match: '$oldDs' != '$newDs'")
-      }
-      setWorkingDataSource(oldName.dataSource) {
-        super.renameTable(oldName, newName)
-      }
+  override def renameTable(oldName: TableIdentifier, newName: TableIdentifier): Unit = {
+    val oldDs = getDataSourceName(oldName)
+    val newDs = getDataSourceName(newName)
+    if (oldDs != newDs) {
+      throw new AnalysisException(
+        s"RENAME TABLE source and destination datasources do not match: '$oldDs' != '$newDs'")
     }
+    setWorkingDataSource(oldName.dataSource) {
+      super.renameTable(oldName, newName)
+    }
+  }
 
   def truncateTable(
       name: TableIdentifier,
@@ -433,17 +430,15 @@ private[xsql] class XSQLSessionCatalog(
   override def dropTable(
       name: TableIdentifier,
       ignoreIfNotExists: Boolean,
-      purge: Boolean): Unit = synchronized {
+      purge: Boolean): Unit = {
     setWorkingDataSource(name.dataSource) {
       super.dropTable(name, ignoreIfNotExists, purge)
     }
   }
 
   override def lookupRelation(name: TableIdentifier): LogicalPlan = {
-    synchronized {
-      setWorkingDataSource(name.dataSource) {
-        super.lookupRelation(name)
-      }
+    setWorkingDataSource(name.dataSource) {
+      super.lookupRelation(name)
     }
   }
 
@@ -459,7 +454,7 @@ private[xsql] class XSQLSessionCatalog(
     }
   }
 
-  override def refreshTable(name: TableIdentifier): Unit = synchronized {
+  override def refreshTable(name: TableIdentifier): Unit = {
     setWorkingDataSource(name.dataSource) {
       super.refreshTable(name)
     }
@@ -795,7 +790,7 @@ private[xsql] class XSQLSessionCatalog(
   /**
    * Look up the [[ExpressionInfo]] associated with the specified function, assuming it exists.
    */
-  override def lookupFunctionInfo(name: FunctionIdentifier): ExpressionInfo = synchronized {
+  override def lookupFunctionInfo(name: FunctionIdentifier): ExpressionInfo = {
     setWorkingDataSource(Option(getDataSourceName(name))) {
       super.lookupFunctionInfo(name)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The driver hang when we use  multiple processes trying to access the XSQLSessionCatalog in XSQL, We print jstack and find a DeadLock. as follows：
``` shell
"Thread-491" #895 daemon prio=5 os_prio=0 tid=0x000000000219b000 nid=0x3ebf waiting for monitor entry [0x00007f17bb2ee000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.apache.spark.sql.xsql.XSQLExternalCatalog.setWorkingDataSource(XSQLExternalCatalog.scala:591)
	- waiting to lock <0x000000066bfb9cb8> (a java.util.concurrent.atomic.AtomicReference)
	at org.apache.spark.sql.xsql.XSQLSessionCatalog.setWorkingDataSource(XSQLSessionCatalog.scala:150)
	at org.apache.spark.sql.xsql.XSQLSessionCatalog.lookupRelation(XSQLSessionCatalog.scala:443)
	- locked <0x000000066be8f0f0> (a org.apache.spark.sql.xsql.XSQLSessionCatalog)
	at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$.org$apache$spark$sql$xsql$XSQLSessionStateBuilder$XSQLResolveRelations$$lookupTableFromCatalog(XSQLSessionStateBuilder.scala:283)
	at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$.resolveRelation(XSQLSessionStateBuilder.scala:236)
	at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$$anonfun$apply$1.applyOrElse(XSQLSessionStateBuilder.scala:266)
	at org.apache.spark.sql.xsql.XSQLSessionStateBuilder$XSQLResolveRelations$$anonfun$apply$1.applyOrElse(XSQLSessionStateBuilder.scala:259)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1$$anonfun$apply$1.apply(AnalysisHelper.scala:90)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$anonfun$resolveOperatorsUp$1$$anonfun$apply$1.apply(AnalysisHelper.scala:90)
"Thread-490" #894 daemon prio=5 os_prio=0 tid=0x0000000002199000 nid=0x3ebe waiting for monitor entry [0x00007f17bb9f4000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.lookupFunction(SessionCatalog.scala:1276)
	- waiting to lock <0x000000066be8f0f0> (a org.apache.spark.sql.xsql.XSQLSessionCatalog)
	at org.apache.spark.sql.hive.HiveSessionCatalog.org$apache$spark$sql$hive$HiveSessionCatalog$$super$lookupFunction(HiveSessionCatalog.scala:131)
	at org.apache.spark.sql.hive.HiveSessionCatalog$$anonfun$3.apply(HiveSessionCatalog.scala:131)
	at org.apache.spark.sql.hive.HiveSessionCatalog$$anonfun$3.apply(HiveSessionCatalog.scala:131)
	at scala.util.Try$.apply(Try.scala:192)
	at org.apache.spark.sql.hive.HiveSessionCatalog.lookupFunction0(HiveSessionCatalog.scala:131)
	at org.apache.spark.sql.hive.HiveSessionCatalog.lookupFunction(HiveSessionCatalog.scala:117)
	at org.apache.spark.sql.xsql.XSQLSessionCatalog.org$apache$spark$sql$xsql$XSQLSessionCatalog$$super$lookupFunction(XSQLSessionCatalog.scala:801)
	at org.apache.spark.sql.xsql.XSQLSessionCatalog$$anonfun$lookupFunction$1.apply(XSQLSessionCatalog.scala:801)
	at org.apache.spark.sql.xsql.XSQLSessionCatalog$$anonfun$lookupFunction$1.apply(XSQLSessionCatalog.scala:801)
	at org.apache.spark.sql.xsql.XSQLExternalCatalog.setWorkingDataSource(XSQLExternalCatalog.scala:598)
	- locked <0x000000066bfb9cb8> (a java.util.concurrent.atomic.AtomicReference)
	at org.apache.spark.sql.xsql.XSQLSessionCatalog.setWorkingDataSource(XSQLSessionCatalog.scala:150)
	at org.apache.spark.sql.xsql.XSQLSessionCatalog.lookupFunction(XSQLSessionCatalog.scala:800)
Found 1 deadlock.
```
This PR solve this DeadLock.

### How was this patch tested?
No UT.
