### PR TITLE
[CORE][ElasticSearch][Mongo] Support discover nested type for ElasticSearch.

### DIFF
--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/DataSourceManager.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/DataSourceManager.scala
@@ -186,7 +186,7 @@ trait DataSourceManager extends ExternalCatalog with Logging {
     dsName = dataSourceName
     defaultCluster = infos.get(CLUSTER)
     enablePushDown = java.lang.Boolean.valueOf(infos.getOrElse(PUSHDOWN, TRUE))
-    discoverSchema = java.lang.Boolean.valueOf(infos.getOrElse(DISCOVER, FALSE))
+    discoverSchema = java.lang.Boolean.valueOf(infos.getOrElse(SCHEMAS_DISCOVER, FALSE))
     enableStream = java.lang.Boolean.valueOf(infos.getOrElse(STREAM, FALSE))
     val whitelistFile = infos.get(WHITELIST)
     if (whitelistFile.isDefined) {
@@ -200,7 +200,7 @@ trait DataSourceManager extends ExternalCatalog with Logging {
     } else if (cachedProperties.contains("schemas.str")) {
       schemaReader(cachedProperties("schemas.str"), schemasMap)
     }
-    val discoverFile = cachedProperties.get(DISCOVER_CONFIG)
+    val discoverFile = cachedProperties.get(SCHEMAS_DISCOVER_CONFIG)
     if (discoverFile.isDefined) {
       parseDiscoverFile(dataSourceName, discoverFile.get)
     }
@@ -996,11 +996,11 @@ object DataSourceManager {
   val VERSION = "version"
   val WHITELIST = "whitelist"
   val PUSHDOWN = "pushdown"
-  val DISCOVER = "discover"
   val STREAM = "stream"
   val SCHEMAS = "schemas"
+  val SCHEMAS_DISCOVER = "schemas.discover"
   val CACHE_LEVEL = "cache.level"
-  val DISCOVER_CONFIG = "discover.config"
+  val SCHEMAS_DISCOVER_CONFIG = "schemas.discover.config"
   val TEMP_FLAG = "temp_flag"
 
   val CLUSTER = "cluster"

--- a/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/DataSourceManager.scala
+++ b/sql/xsql/src/main/scala/org/apache/spark/sql/xsql/DataSourceManager.scala
@@ -26,6 +26,7 @@ import scala.util.matching.Regex
 import net.sf.json.JSONArray
 
 import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.CatalystTypeConverters.convertToScala
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedAttribute}
@@ -46,7 +47,7 @@ import org.apache.spark.util.Utils
  * [[ExternalCatalog]]'s abstract methods with default implementation which means specific kind of
  * operation on this datasource is not supported for now.
  */
-trait DataSourceManager extends ExternalCatalog {
+trait DataSourceManager extends ExternalCatalog with Logging {
   import DataSourceManager._
 
   def shortName(): String
@@ -62,6 +63,11 @@ trait DataSourceManager extends ExternalCatalog {
    * If true, XSQL will allow queries using the API of the underlying data source.
    */
   private var enablePushDown: Boolean = true
+
+  /**
+   * If true, XSQL will discover the schema of tables in the data source.
+   */
+  private var discoverSchema: Boolean = false
 
   /**
    * If true, XSQL will allow queries by structured stream API.
@@ -180,6 +186,7 @@ trait DataSourceManager extends ExternalCatalog {
     dsName = dataSourceName
     defaultCluster = infos.get(CLUSTER)
     enablePushDown = java.lang.Boolean.valueOf(infos.getOrElse(PUSHDOWN, TRUE))
+    discoverSchema = java.lang.Boolean.valueOf(infos.getOrElse(DISCOVER, FALSE))
     enableStream = java.lang.Boolean.valueOf(infos.getOrElse(STREAM, FALSE))
     val whitelistFile = infos.get(WHITELIST)
     if (whitelistFile.isDefined) {
@@ -193,7 +200,7 @@ trait DataSourceManager extends ExternalCatalog {
     } else if (cachedProperties.contains("schemas.str")) {
       schemaReader(cachedProperties("schemas.str"), schemasMap)
     }
-    val discoverFile = cachedProperties.get(DISCOVER_SCHEMA)
+    val discoverFile = cachedProperties.get(DISCOVER_CONFIG)
     if (discoverFile.isDefined) {
       parseDiscoverFile(dataSourceName, discoverFile.get)
     }
@@ -278,6 +285,11 @@ trait DataSourceManager extends ExternalCatalog {
    */
   def isPushDown(runtimeConf: SQLConf, dataSourceName: String, plan: LogicalPlan): Boolean =
     enablePushDown
+
+  /**
+   * Check if the specified table contains fields need to discover.
+   */
+  def isDiscover: Boolean = discoverSchema
 
   /**
    * Structured streaming enabled or not.
@@ -493,7 +505,32 @@ trait DataSourceManager extends ExternalCatalog {
       db: String,
       originDB: String,
       table: String): Option[CatalogTable] = {
-    throw new UnsupportedOperationException(s"Get ${shortName()} raw table not supported!")
+    if (isDiscover) {
+      logDebug(s"Discovering $dsName.$db.$table, $dsName.$originDB.$table in fact.")
+      discoverRawTable(db, originDB, table)
+    } else {
+      fastGetRawTable(db, originDB, table)
+    }
+  }
+
+  /**
+   * Discover the schema of the specified table.
+   */
+  protected def discoverRawTable(
+      db: String,
+      originDB: String,
+      table: String): Option[CatalogTable] = {
+    throw new UnsupportedOperationException(s"Discover ${shortName()} raw table not supported!")
+  }
+
+  /**
+   * Get the schema of the specified table in fast way.
+   */
+  protected def fastGetRawTable(
+      db: String,
+      originDB: String,
+      table: String): Option[CatalogTable] = {
+    throw new UnsupportedOperationException(s"Get ${shortName()} raw table fast not supported!")
   }
 
   /**
@@ -959,10 +996,11 @@ object DataSourceManager {
   val VERSION = "version"
   val WHITELIST = "whitelist"
   val PUSHDOWN = "pushdown"
+  val DISCOVER = "discover"
   val STREAM = "stream"
   val SCHEMAS = "schemas"
   val CACHE_LEVEL = "cache.level"
-  val DISCOVER_SCHEMA = "discover"
+  val DISCOVER_CONFIG = "discover.config"
   val TEMP_FLAG = "temp_flag"
 
   val CLUSTER = "cluster"


### PR DESCRIPTION
### What changes were proposed in this pull request?
The ElasticSearch index log contains a type details. The mapping of details is:
```
curl -H 'Content-Type: application/json' -XGET 'http://127.0.0.1:9228/log/details/_mapping?pretty'
{
  "log" : {
    "mappings" : {
      "details" : {
        "dynamic" : "strict",
        "_all" : {
          "enabled" : false
        },
        "properties" : {
          "hasLog" : {
            "type" : "boolean"
          },
          "logDetail" : {
            "type" : "nested",
            "dynamic" : "strict",
            "properties" : {
              "confidence" : {
                "type" : "keyword"
              },
              "danger" : {
                "type" : "keyword"
              },
              "dbt" : {
                "type" : "date",
                "format" : "yyyy-MM-dd HH:mm:ss"
              },
              "detectNotify" : {
                "type" : "boolean"
              },
              "virusName" : {
                "type" : "text",
                "analyzer" : "virusinfo"
              }
            }
          },
          "md5" : {
            "type" : "keyword"
          },
          "sha1" : {
            "type" : "keyword"
          },
          "sha256" : {
            "type" : "keyword"
          }
        }
      }
    }
  }
}
```
We know the property `logDetail` uses nested type. `XSQL` parse nested type of ElasticSearch as `nested`. The `nested` just used for display. For example:
```
spark-xsql> desc details;
20/01/22 14:49:16 INFO SparkXSQLShell: current SQL: desc details
20/01/22 14:49:16 WARN SparkXSQLShell: hive.cli.print.header not configured, so doesn't print colum's name.
hasLog  boolean NULL
logDetail       nested  NULL
md5     keyword NULL
sha1    keyword NULL
sha256  keyword NULL
Time taken: 0.269 s
```
The type of column logDetail display as `nested`. But Spark can't use this type, we need to transform the nested type of ElasticSearch as StructType or ArrayType(StructType).
Then we can query data with the sub properties of nested type, such as:
```
select hasLog, logDetail.confidence from details limit 5;
select logDetail.confidence from details group by logDetail.confidence;
select * from details where logDetail.confidence[0]="HEURISTIC";
```
This PR will resolve the issue and parse nested as the data type that Spark can use.
```
spark-xsql> desc details;
20/01/22 15:07:09 INFO SparkXSQLShell: current SQL: desc details
20/01/22 15:07:13 WARN SparkXSQLShell: hive.cli.print.header not configured, so doesn't print colum's name.
hasLog  boolean NULL
logDetail       array<struct<confidence:string,danger:string,dbt:string,detectNotify:boolean,virusName:string>> NULL
md5     string  NULL
sha1    string  NULL
sha256  string  NULL
Time taken: 3.768 s
```
Note: This PR reference https://github.com/apache/spark/pull/23353

### How was this patch tested?
No UT.
